### PR TITLE
docs: Align the documentation with actual examples

### DIFF
--- a/docs/guide/setup-using-jest.md
+++ b/docs/guide/setup-using-jest.md
@@ -87,17 +87,22 @@ Next, create a file that will export functions for testing:
 ```ts [testing-functions.ts]
 // 1. Import the factory that will create functions bound to `jest`
 import { createTestUtils } from '@morev/stylelint-testing-library';
-// 2. Import a module that extends `jest` matchers
-//    for more detailed error messages
+// 2. Import all the rules you want to test - this is usually
+// the file that is the default export of your package.
+// This step is generally optional - you can do it later,
+// but it's recommended, as it reduces the amount of boilerplate code.
+import plugins from './index';
+// 3. Import a module that extends `jest` matchers
+// for more detailed error messages
 import 'jest-expect-message';
 
-// 3. Create testing functions
+// 4. Create testing functions
 // To see all available `createTestUtils` options, please
 // refer to the `API Reference` section of this documentation
 // or use inline IDE suggestions.
 const { createTestRule, createTestRuleConfig } = createTestUtils();
 
-// 4. Export these functions
+// 5. Export these functions
 // Unfortunately, you will need to import these functions
 // within each of your test files, as `jest` test functions
 // (`describe`, `it`, `expect`, etc) only exist in the context of such files.
@@ -109,11 +114,23 @@ export { createTestRule, createTestRuleConfig };
 
 ```ts [testing-functions.ts (without-comments)]
 import { createTestUtils } from '@morev/stylelint-testing-library';
+import plugins from './index';
 import 'jest-expect-message';
 
-const { createTestRule, createTestRuleConfig } = createTestUtils();
+const { createTestRule, createTestRuleConfig } = createTestUtils({ plugins });
 
 export { createTestRule, createTestRuleConfig };
+
+```
+
+```ts [index.ts]
+// All the rules that your plugin provides.
+// This file is usually the default export of your package.
+import lowercaseSelectorsRule from './rules/lowercase-selectors';
+
+export default [
+  lowercaseSelectorsRule,
+];
 
 ```
 

--- a/docs/guide/setup-using-node-test.md
+++ b/docs/guide/setup-using-node-test.md
@@ -37,15 +37,22 @@ import { describe, it } from 'node:test';
 // 2. Import the factory that will create functions bound to Node test runner
 import { createTestUtils } from '@morev/stylelint-testing-library';
 
-// 3. Create testing functions
+// 3. Import all the rules you want to test - this is usually
+// the file that is the default export of your package.
+// This step is generally optional - you can do it later,
+// but it's recommended, as it reduces the amount of boilerplate code.
+import plugins from './index.js';
+
+// 4. Create testing functions
 // To see all available `createTestUtils` options, please
 // refer to the `API Reference` section of this documentation
 // or use inline IDE suggestions.
 const { createTestRule, createTestRuleConfig } = createTestUtils({
   testFunctions: { it, describe, assert },
+  plugins,
 });
 
-// 4. Make these functions globally available
+// 5. Make these functions globally available
 // If you don't like to declare test functions globally -
 // you should export these functions from a file
 // and import it in each test.
@@ -53,10 +60,11 @@ globalThis.createTestRule = createTestRule;
 globalThis.createTestRuleConfig = createTestRuleConfig;
 ```
 
-```ts [node.test.setup.js (without comments)]
+```js [node.test.setup.js (without comments)]
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createTestUtils } from '@morev/stylelint-testing-library';
+import plugins from './index.js';
 
 const { createTestRule, createTestRuleConfig } = createTestUtils({
   testFunctions: { it, describe, assert },
@@ -64,6 +72,17 @@ const { createTestRule, createTestRuleConfig } = createTestUtils({
 
 globalThis.createTestRule = createTestRule;
 globalThis.createTestRuleConfig = createTestRuleConfig;
+```
+
+```js [index.js]
+// All the rules that your plugin provides.
+// This file is usually the default export of your package.
+import lowercaseSelectorsRule from './rules/lowercase-selectors.js';
+
+export default [
+  lowercaseSelectorsRule,
+];
+
 ```
 
 :::

--- a/docs/guide/setup-using-vitest.md
+++ b/docs/guide/setup-using-vitest.md
@@ -28,26 +28,33 @@ import { assert, describe, expect, it } from 'vitest';
 // 2. Import the factory that will create functions bound to `vitest`
 import { createTestUtils } from '@morev/stylelint-testing-library';
 
-// 3. Import types if you need to.
+// 3. Import all the rules you want to test - this is usually
+// the file that is the default export of your package.
+// This step is generally optional - you can do it later,
+// but it's recommended, as it reduces the amount of boilerplate code.
+import plugins from './index';
+
+// 4. Import types if you need to.
 // You can declare global types directly in the same file (below).
 import type { CreateTestRule, CreateTestRuleConfig } from '@morev/stylelint-testing-library';
 
-// 4. Create testing functions
+// 5. Create testing functions
 // Passing `testFunctions` is optional if you prefer globally declared functions.
 // To see all available `createTestUtils` options, please
 // refer to the `API Reference` section of this documentation
 // or use inline IDE suggestions.
 const { createTestRule, createTestRuleConfig } = createTestUtils({
   testFunctions: { assert, describe, expect, it },
+  plugins,
 });
 
-// 5. Make these functions globally available
+// 6. Make these functions globally available
 // If you don't like to declare test functions globally -
 // I guess you know how to design getting these functions as a separate hook :)
 globalThis.createTestRule = createTestRule;
 globalThis.createTestRuleConfig = createTestRuleConfig;
 
-// 6. Declare a type for globally registered functions
+// 7. Declare a type for globally registered functions
 // It's optional, but objectively there's no reason not to do it.
 declare global {
   var createTestRule: CreateTestRule;
@@ -59,10 +66,12 @@ declare global {
 ```ts [vitest.setup.ts (without comments)]
 import { assert, describe, expect, it } from 'vitest';
 import { createTestUtils } from '@morev/stylelint-testing-library';
+import plugins from './index';
 import type { CreateTestRule, CreateTestRuleConfig } from '@morev/stylelint-testing-library';
 
 const { createTestRule, createTestRuleConfig } = createTestUtils({
   testFunctions: { assert, describe, expect, it },
+  plugins,
 });
 
 globalThis.createTestRule = createTestRule;
@@ -72,6 +81,17 @@ declare global {
   var createTestRule: CreateTestRule;
   var createTestRuleConfig: CreateTestRuleConfig;
 }
+
+```
+
+```ts [index.ts]
+// All the rules that your plugin provides.
+// This file is usually the default export of your package.
+import lowercaseSelectorsRule from './rules/lowercase-selectors';
+
+export default [
+  lowercaseSelectorsRule,
+];
 
 ```
 


### PR DESCRIPTION
Fixes #62 

Really just aligns the documentation with the code examples, making things more transparent.
Links are already fixed in the `master` branch.

@MangelMaxime if you have any other useful additions, feel free to speak up - otherwise, I'll merge this in a day or two :)