### PR TITLE
feat: Add `contextNewlineFallback` setting

### DIFF
--- a/__tests__/_playground/test-rule.test.ts
+++ b/__tests__/_playground/test-rule.test.ts
@@ -1,3 +1,4 @@
+import { EOL } from 'node:os';
 import { createTestUtils } from '#';
 import { messages, plugin, ruleName } from '../fixtures/plugin-foo';
 
@@ -93,6 +94,46 @@ testRule({
 			code: '#a {}',
 			codeFilename: 'bar.css',
 			message: messages.expectFilename('foo.css', 'bar.css'),
+		},
+	],
+});
+
+
+testRule({
+	config: ['.a', { prependNewline: true }],
+
+	reject: [
+		{
+			description: 'preserves CRLF if explicitly defined',
+			code: '.a {\r\n}',
+			fixed: '\r\n.a {\r\n}',
+			message: messages.expectNewline('.a'),
+		},
+		{
+			description: 'preserves LF if explicitly defined',
+			code: '.a {\n}',
+			fixed: '\n.a {\n}',
+			message: messages.expectNewline('.a'),
+		},
+		{
+			description: 'falls back to system EOL by default',
+			code: '.a {}',
+			fixed: `${EOL}.a {}`,
+			message: messages.expectNewline('.a'),
+		},
+		{
+			description: 'falls back to CRLF if defined',
+			code: '.a {}',
+			fixed: `\r\n.a {}`,
+			contextNewlineFallback: 'crlf',
+			message: messages.expectNewline('.a'),
+		},
+		{
+			description: 'falls back to LF if defined',
+			code: '.a {}',
+			fixed: `\n.a {}`,
+			contextNewlineFallback: 'lf',
+			message: messages.expectNewline('.a'),
 		},
 	],
 });

--- a/__tests__/fixtures/plugin-foo.ts
+++ b/__tests__/fixtures/plugin-foo.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import-x/exports-last */
 import { basename } from 'node:path';
-import { isString } from '@morev/utils';
+import { isBoolean, isString } from '@morev/utils';
 import stylelint from 'stylelint';
 import type { Rule } from 'stylelint';
 
@@ -14,9 +14,10 @@ export const ruleName = 'plugin/foo';
 export const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `No \`${selector.toString()}\` selector`,
 	expectFilename: (expected, actual) => `Expect \`${actual.toString()}\` to be \`${expected.toString()}\``,
+	expectNewline: (selector) => `Expect to start with a newline in the \`${selector.toString()}\` selector`,
 });
 
-const ruleFunction: Rule = (primary, secondaryOptions) => {
+const ruleFunction: Rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -25,6 +26,7 @@ const ruleFunction: Rule = (primary, secondaryOptions) => {
 			actual: secondaryOptions,
 			possible: {
 				filename: [isString],
+				prependNewline: [isBoolean],
 			},
 			optional: true,
 		});
@@ -44,6 +46,19 @@ const ruleFunction: Rule = (primary, secondaryOptions) => {
 
 			return;
 		}
+
+		secondaryOptions?.prependNewline && root.walkRules((rule) => {
+			report({
+				result,
+				ruleName,
+				message: messages.expectNewline(rule.selector),
+				node: rule,
+				word: rule.selector,
+				fix: () => {
+					rule.raws.before = (context.newline ?? '') + (rule.raws.before ?? '');
+				},
+			});
+		});
 
 		root.walkRules((rule) => {
 			const { selector } = rule;

--- a/__tests__/utils/get-stylelint-options.test.ts
+++ b/__tests__/utils/get-stylelint-options.test.ts
@@ -1,9 +1,54 @@
-import { assert, describe, expect, it } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
+import { isString } from '@morev/utils';
 import { createUniversalMappings, getStylelintOptions } from '#utils';
+import type { Plugin, Rule, RuleContext } from 'stylelint';
+
+type RulePlugin = Extract<Plugin, { rule: Rule; ruleName: string }>;
 
 const testFunctions = { describe, it, assert };
 const universal = createUniversalMappings(testFunctions);
 const TEST_CODE = 'a {}';
+
+const createPlugin = () => {
+	let capturedContext: RuleContext | undefined;
+	const ruleName = 'plugin/foo';
+
+	const rule = vi.fn((primary, secondaryOptions, context: RuleContext) => {
+		capturedContext = context;
+		return () => ({ primary, secondaryOptions, context });
+	}) as unknown as Rule;
+
+	rule.ruleName = ruleName;
+	rule.messages = {};
+	rule.meta = { fixable: true, url: '' };
+
+	const plugin: Plugin = { ruleName, rule };
+
+	return {
+		plugin,
+		rule,
+		getCapturedContext: () => capturedContext,
+	};
+};
+
+const getFirstPlugin = (options: ReturnType<typeof getStylelintOptions>) => {
+	const { plugins } = options.config;
+
+	return Array.isArray(plugins)
+		? plugins[0]
+		: plugins;
+};
+
+const expectRulePlugin = (plugin: Plugin | string | undefined): RulePlugin => {
+	expect(plugin).toBeDefined();
+	expect(typeof plugin).not.toBe('string');
+
+	if (!plugin || isString(plugin) || !('rule' in plugin)) {
+		throw new TypeError('Expected plugin object with direct `rule` property');
+	}
+
+	return plugin;
+};
 
 describe('utils', () => {
 	describe('get-stylelint-options', () => {
@@ -90,6 +135,103 @@ describe('utils', () => {
 					},
 					customSyntax: undefined,
 					codeFilename: undefined,
+				});
+			});
+		});
+
+		describe('contextNewlineFallback', () => {
+			it('Wraps object plugins when `contextNewlineFallback` is set and code has no linebreaks', () => {
+				const { plugin, rule, getCapturedContext } = createPlugin();
+				const options = getStylelintOptions({ code: TEST_CODE, contextNewlineFallback: 'lf' }, {
+					universal,
+					groupIndex: 1,
+					testUtilsSchema: {
+						testFunctions,
+						plugins: [plugin],
+					},
+					testRuleSchema: { config: true, accept: [] },
+					factorySchema: { ruleName: 'foo' },
+				});
+
+				const wrappedPlugin = expectRulePlugin(getFirstPlugin(options));
+				const context = { fix: true };
+
+				expect(wrappedPlugin).not.toBe(plugin);
+				expect(wrappedPlugin.rule).not.toBe(rule);
+				expect(wrappedPlugin.rule.ruleName).toBe(rule.ruleName);
+				expect(wrappedPlugin.rule.messages).toBe(rule.messages);
+				expect('newline' in context).toBe(false);
+
+				wrappedPlugin.rule(true, undefined, context);
+
+				expect(getCapturedContext()).toMatchObject({
+					fix: true,
+					newline: '\n',
+				});
+				expect(getCapturedContext()).not.toBe(context);
+				expect('newline' in context).toBe(false);
+			});
+
+			it('Does not wrap object plugins when code already contains linebreaks', () => {
+				const { plugin, rule } = createPlugin();
+				const options = getStylelintOptions({ code: 'a {\n}', contextNewlineFallback: 'crlf' }, {
+					universal,
+					groupIndex: 1,
+					testUtilsSchema: {
+						testFunctions,
+						plugins: [plugin],
+					},
+					testRuleSchema: { config: true, accept: [] },
+					factorySchema: { ruleName: 'foo' },
+				});
+
+				const actualPlugin = expectRulePlugin(getFirstPlugin(options));
+
+				expect(actualPlugin).toBe(plugin);
+				expect(actualPlugin.rule).toBe(rule);
+			});
+
+			it('Does not wrap string plugins even when `contextNewlineFallback` is set', () => {
+				const options = getStylelintOptions({ code: TEST_CODE, contextNewlineFallback: 'crlf' }, {
+					universal,
+					groupIndex: 1,
+					testUtilsSchema: {
+						testFunctions,
+						plugins: ['./plugin.js'],
+					},
+					testRuleSchema: { config: true, accept: [] },
+					factorySchema: { ruleName: 'foo' },
+				});
+
+				expect(options.config?.plugins).toStrictEqual(['./plugin.js']);
+			});
+
+			it('Uses test-case fallback with higher priority than schema fallbacks', () => {
+				const { plugin, getCapturedContext } = createPlugin();
+				const options = getStylelintOptions({ code: TEST_CODE, contextNewlineFallback: 'crlf' }, {
+					universal,
+					groupIndex: 1,
+					testUtilsSchema: {
+						testFunctions,
+						plugins: [plugin],
+						contextNewlineFallback: 'lf',
+					},
+					testRuleSchema: {
+						config: true,
+						accept: [],
+						contextNewlineFallback: 'lf',
+					},
+					factorySchema: {
+						ruleName: 'foo',
+						contextNewlineFallback: 'lf',
+					},
+				});
+
+				const wrappedPlugin = expectRulePlugin(getFirstPlugin(options));
+				wrappedPlugin.rule(true, undefined, {});
+
+				expect(getCapturedContext()).toMatchObject({
+					newline: '\r\n',
 				});
 			});
 		});

--- a/docs/_parts/properties/context-newline-fallback.md
+++ b/docs/_parts/properties/context-newline-fallback.md
@@ -1,0 +1,11 @@
+Controls which line break notation should be provided in the Stylelint context (`context.newline`)
+if the test string does not contain an explicit line break.
+
+You can read the details of the issue [in the Stylelint repository](https://github.com/stylelint/stylelint/issues/9281).
+
+```ts
+/**
+ * @default 'system'
+ */
+type ContextNewlineFallback = 'system' | 'lf' | 'crlf';
+```

--- a/docs/api/create-test-rule.md
+++ b/docs/api/create-test-rule.md
@@ -38,6 +38,8 @@ All others are optional, but can improve your DX.
 
 <!-- @include: @/_parts/properties/rule-name.md -->
 
+---
+
 ### `plugins`
 
 The same option as described in [`createTestUtils > Options > plugins`](/api/create-test-utils#plugins)
@@ -45,41 +47,60 @@ but takes precedence over it if specified, allowing to overwrite the defaults fo
 
 **Required** if `plugins` is not specified when declaring `createTestUtils`.
 
-::: details Show original description
+:::: details Show original description
 
 <!-- @include: @/_parts/properties/plugins.md#description -->
 
-:::
+::::
+
+---
 
 ### `extraRules`
 
 The same option as described in [`createTestUtils > Options > extraRules`](/api/create-test-utils#extrarules)
 but, if specified, appended to these rules.
 
-::: details Show original description
+:::: details Show original description
 
 <!-- @include: @/_parts/properties/extra-rules.md#description -->
 
-:::
+::::
+
+---
 
 ### `customSyntax`
 
 The same option as described in [`createTestUtils > Options > customSyntax`](/api/create-test-utils#customsyntax)
 but takes precedence over it if specified, allowing to overwrite the defaults for a particular rule.
 
-::: details Show original description
+:::: details Show original description
 
 <!-- @include: @/_parts/properties/custom-syntax.md#description -->
 
-:::
+::::
+
+---
 
 ### `autoStripIndent`
 
 The same option as described in [`createTestUtils > Options > autoStripIndent`](/api/create-test-utils#autostripindent)
 but takes precedence over it if specified, allowing to overwrite the defaults for a particular rule.
 
-::: details Show original description
+:::: details Show original description
 
 <!-- @include: @/_parts/properties/auto-strip-indent.md -->
 
-:::
+::::
+
+---
+
+### `contextNewlineFallback`
+
+The same option as described in [`createTestUtils > Options > contextNewlineFallback`](/api/create-test-utils#contextnewlinefallback)
+but takes precedence over it if specified, allowing to overwrite the defaults for a particular rule.
+
+:::: details Show original description
+
+<!-- @include: @/_parts/properties/context-newline-fallback.md -->
+
+::::

--- a/docs/api/create-test-utils.md
+++ b/docs/api/create-test-utils.md
@@ -51,18 +51,23 @@ If your test platform injects them into the global scope, the module will pick t
 
 ---
 
-
 ### `plugins`
 
 <!-- @include: @/_parts/properties/plugins.md -->
+
+---
 
 ### `extraRules`
 
 <!-- @include: @/_parts/properties/extra-rules.md -->
 
+---
+
 ### `customSyntax`
 
 <!-- @include: @/_parts/properties/custom-syntax.md -->
+
+---
 
 ### `testGroupWithoutDescriptionAppearance`
 
@@ -178,6 +183,8 @@ testRule({
 
 ::::
 
+---
+
 ### `testCaseWithoutDescriptionAppearance`
 
 The option controls how test cases are displayed in the console output if they do not have a description.
@@ -230,6 +237,8 @@ the ability to set a description for a test cases.
 
 :::
 
+---
+
 ### `autoStripIndent`
 
 <!-- @include: @/_parts/properties/auto-strip-indent.md -->
@@ -237,5 +246,11 @@ the ability to set a description for a test cases.
 ::: info Note
 You can always redefine this global setting for a group of tests or a single test.
 :::
+
+---
+
+### `contextNewlineFallback`
+
+<!-- @include: @/_parts/properties/context-newline-fallback.md -->
 
 [`testRule`]: /api/test-rule

--- a/docs/api/test-rule.md
+++ b/docs/api/test-rule.md
@@ -55,6 +55,8 @@ The option only exists to ensure that the project can be a drop-in replacement f
 
 :::
 
+---
+
 ### `plugins`
 
 The same option as described in [`createTestUtils > Options > plugins`](/api/create-test-utils#plugins)
@@ -71,6 +73,8 @@ The option only exists to ensure that the project can be a drop-in replacement f
 
 :::
 
+---
+
 ### `extraRules`
 
 The same option as described in [`createTestUtils > Options > extraRules`](/api/create-test-utils#extrarules)
@@ -81,6 +85,8 @@ but, if specified, appended to these rules.
 <!-- @include: @/_parts/properties/extra-rules.md#description -->
 
 :::
+
+---
 
 ### `description`
 
@@ -108,6 +114,8 @@ testRule({
 ```
 
 :::
+
+---
 
 ### `config`
 
@@ -143,9 +151,13 @@ stylelint.lint({
 
 :::
 
+---
+
 ### `codeFilename`
 
 <!-- @include: @/_parts/properties/code-filename.md -->
+
+---
 
 ### `customSyntax`
 
@@ -159,10 +171,14 @@ but takes precedence over them if specified, allowing to overwrite the defaults 
 
 :::
 
+---
+
 ### `accept` & `reject`
 
 An array of tests that should pass without warnings from Stylelint or where an error is expected, respectively. \
 See more info about test cases in [Test cases](#test-cases) section below.
+
+---
 
 ### `skip` & `only`
 
@@ -188,6 +204,7 @@ testRule({
 });
 ```
 
+---
 
 ### `autoStripIndent`
 
@@ -197,6 +214,19 @@ but takes precedence over it if specified, allowing to overwrite the defaults fo
 :::: details Show original description
 
 <!-- @include: @/_parts/properties/auto-strip-indent.md -->
+
+::::
+
+---
+
+### `contextNewlineFallback`
+
+The same option as described in [`createTestUtils > Options > contextNewlineFallback`](/api/create-test-utils#contextnewlinefallback)
+but takes precedence over it if specified, allowing to overwrite the defaults for a particular rule.
+
+:::: details Show original description
+
+<!-- @include: @/_parts/properties/context-newline-fallback.md -->
 
 ::::
 
@@ -300,6 +330,17 @@ but takes precedence over it if specified, allowing to overwrite the defaults fo
 :::: details Show original description
 
 <!-- @include: @/_parts/properties/auto-strip-indent.md#description -->
+
+::::
+
+#### `contextNewlineFallback`
+
+The same option as described in [`contextNewlineFallback`](#contextnewlinefallback) above
+but takes precedence over it if specified, allowing to overwrite the defaults for a particular rule.
+
+:::: details Show original description
+
+<!-- @include: @/_parts/properties/context-newline-fallback.md -->
 
 ::::
 

--- a/src/types/create-test-rule-schema.ts
+++ b/src/types/create-test-rule-schema.ts
@@ -39,4 +39,14 @@ export type CreateTestRuleSchema = {
 	 * @default false
 	 */
 	autoStripIndent?: boolean;
+
+	/**
+	 * Controls the fallback value of `context.newline`
+	 * when the input source contains no linebreaks.
+	 *
+	 * @see https://github.com/stylelint/stylelint/issues/9281
+	 *
+	 * @default 'system'
+	 */
+	contextNewlineFallback?: 'system' | 'lf' | 'crlf';
 };

--- a/src/types/create-test-utils-schema.ts
+++ b/src/types/create-test-utils-schema.ts
@@ -59,4 +59,14 @@ export type CreateTestUtilsSchema = {
 	 * @default false
 	 */
 	autoStripIndent?: boolean;
+
+	/**
+	 * Controls the fallback value of `context.newline`
+	 * when the input source contains no linebreaks.
+	 *
+	 * @see https://github.com/stylelint/stylelint/issues/9281
+	 *
+	 * @default 'system'
+	 */
+	contextNewlineFallback?: 'system' | 'lf' | 'crlf';
 };

--- a/src/types/test-case.ts
+++ b/src/types/test-case.ts
@@ -44,4 +44,14 @@ export type TestCase = {
 	 * @default false
 	 */
 	autoStripIndent?: boolean;
+
+	/**
+	 * Controls the fallback value of `context.newline`
+	 * when the input source contains no linebreaks.
+	 *
+	 * @see https://github.com/stylelint/stylelint/issues/9281
+	 *
+	 * @default 'system'
+	 */
+	contextNewlineFallback?: 'system' | 'lf' | 'crlf';
 };

--- a/src/types/test-rule-schema.ts
+++ b/src/types/test-rule-schema.ts
@@ -71,6 +71,16 @@ export type TestRuleSchema = {
 	autoStripIndent?: boolean;
 
 	/**
+	 * Controls the fallback value of `context.newline`
+	 * when the input source contains no linebreaks.
+	 *
+	 * @see https://github.com/stylelint/stylelint/issues/9281
+	 *
+	 * @default 'system'
+	 */
+	contextNewlineFallback?: 'system' | 'lf' | 'crlf';
+
+	/**
 	 * Extra rules to apply.
 	 *
 	 * @default {}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,37 @@
+import { isString, isUndefined, toNumber, tsObject } from '@morev/utils';
+import type { PlainObject } from '@morev/utils';
+
+/**
+ * Clears the object of keys that have the value `undefined`.
+ *
+ * @param   source   The source object.
+ *
+ * @returns          A new object without keys that was declared as `undefined` in the source object.
+ */
+export const omitUndefinedValues = (source: PlainObject<unknown>) => {
+	return tsObject.fromEntries(
+		tsObject.entries(source)
+			.filter(([key, value]) => !isUndefined(value)),
+	);
+};
+
+/**
+ * Retrieves (from a stack trace) the line number of the call
+ * that follows the call with the specified function.
+ *
+ * @param   previousCallFunctionName   The name of the function that precedes the desired output.
+ *
+ * @returns                            Number of the line or `null` in case it could not be determined.
+ */
+export const fetchErrorLine = (previousCallFunctionName: string) => {
+	try {
+		throw new Error('error-to-catch-the-line');
+	} catch (error: any) {
+		if (!error.stack || !isString(error.stack)) return null;
+		const stack = error.stack.split('\n');
+		const errorFileLineIndex = stack
+			.findIndex((item: string) => item.includes(previousCallFunctionName)) + 1;
+
+		return toNumber(stack[errorFileLineIndex]?.match(/(\d+):\d+$/)?.[1], null);
+	}
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './common';
+export * from './stylelint';
+export * from './test-platform';

--- a/src/utils/stylelint.ts
+++ b/src/utils/stylelint.ts
@@ -1,0 +1,77 @@
+import stylelint from 'stylelint';
+import type { LinterOptions, LinterResult } from 'stylelint';
+import type { TestCase } from '#types';
+import type { InternalTestRuleSchema } from '#types/internal';
+
+/**
+ * Gets the resulting CSS string from the `linterOutput`,
+ * checking for necessary parts in the process.
+ *
+ * @param   linterOutput   Stylelint output.
+ *
+ * @returns                Resulting CSS string of the Stylelint output
+ *                         or `null` in case of an error.
+ */
+const getOutputCss = (linterOutput: LinterResult) => {
+	const { results } = linterOutput;
+	const { _postcssResult: result } = results[0];
+
+	if (result?.root && result?.opts) {
+		return result.root.toString(result.opts.syntax);
+	}
+
+	return null;
+};
+
+/**
+ * Gets options to pass into `stylelint.lint()` method
+ * considering test case and schema options.
+ *
+ * @param   testCase   A test case.
+ * @param   schema     A test schema.
+ *
+ * @returns            Options ready to pass into `stylelint.lint()` method.
+ */
+export const getStylelintOptions = (testCase: TestCase, schema: InternalTestRuleSchema): LinterOptions => {
+	const { testRuleSchema, factorySchema, testUtilsSchema } = schema;
+	const plugins = testRuleSchema.plugins ?? factorySchema.plugins ?? testUtilsSchema.plugins;
+	const ruleName = testRuleSchema.ruleName ?? factorySchema.ruleName;
+
+	return {
+		code: testCase.code,
+		config: {
+			plugins,
+			rules: {
+				[ruleName]: testRuleSchema.config,
+				...testUtilsSchema.extraRules,
+				...factorySchema.extraRules,
+				...testRuleSchema.extraRules,
+			},
+		},
+		customSyntax: (() => {
+			if ('customSyntax' in testCase) return testCase.customSyntax;
+			if ('customSyntax' in testRuleSchema) return testRuleSchema.customSyntax;
+			if ('customSyntax' in factorySchema) return factorySchema.customSyntax;
+			return testUtilsSchema.customSyntax;
+		})(),
+		codeFilename: (() => {
+			if ('codeFilename' in testCase) return testCase.codeFilename;
+			if ('codeFilename' in testRuleSchema) return testRuleSchema.codeFilename;
+		})(),
+	};
+};
+
+/**
+ * Runs `stylelint.lint` method with specified options.
+ *
+ * @param   options   Stylelint options.
+ *
+ * @returns           An object containing linter output and its extracted result.
+ */
+export const lintWithOptions = async (options: LinterOptions) => {
+	const output = await stylelint.lint(options);
+	const { results: [result] } = output;
+	const outputCss = getOutputCss(output);
+
+	return { output, result, outputCss };
+};

--- a/src/utils/stylelint.ts
+++ b/src/utils/stylelint.ts
@@ -58,7 +58,7 @@ export const getStylelintOptions = (testCase: TestCase, schema: InternalTestRule
 			if ('codeFilename' in testCase) return testCase.codeFilename;
 			if ('codeFilename' in testRuleSchema) return testRuleSchema.codeFilename;
 		})(),
-	};
+	} satisfies LinterOptions;
 };
 
 /**

--- a/src/utils/stylelint.ts
+++ b/src/utils/stylelint.ts
@@ -1,5 +1,6 @@
+import { deepClone, isString, toArray } from '@morev/utils';
 import stylelint from 'stylelint';
-import type { LinterOptions, LinterResult } from 'stylelint';
+import type { LinterOptions, LinterResult, Plugin, Rule, RuleContext } from 'stylelint';
 import type { TestCase } from '#types';
 import type { InternalTestRuleSchema } from '#types/internal';
 
@@ -24,6 +25,81 @@ const getOutputCss = (linterOutput: LinterResult) => {
 };
 
 /**
+ * Wraps a Stylelint rule and overrides the `context.newline` value.
+ *
+ * This is required because Stylelint derives `context.newline`
+ * from the tested source code. When the source contains no line breaks,
+ * the value becomes platform-dependent (`\n` or `\r\n`), which makes
+ * snapshot and autofix tests non-deterministic across operating systems.
+ *
+ * @see https://github.com/stylelint/stylelint/issues/9281
+ *
+ * @param   rule           Original Stylelint rule function.
+ * @param   newlineStyle   Newline style to inject into the rule context.
+ *
+ * @returns                Wrapped rule with overridden `context.newline`.
+ */
+const withContextNewline = (rule: Rule, newlineStyle: 'lf' | 'crlf') => {
+	const newlineSequence = newlineStyle === 'lf'
+		? '\n'
+		: '\r\n';
+
+	const wrappedRule = (
+		primaryOption: any,
+		secondaryOptions: any,
+		context: RuleContext,
+	) => {
+		return rule(
+			primaryOption,
+			secondaryOptions,
+			Object.create(
+				Object.getPrototypeOf(context),
+				{
+					...Object.getOwnPropertyDescriptors(context),
+					newline: {
+						value: newlineSequence,
+						writable: true,
+						enumerable: true,
+						configurable: true,
+					},
+				},
+			),
+		);
+	};
+
+	Object.defineProperties(
+		wrappedRule,
+		Object.getOwnPropertyDescriptors(rule),
+	);
+
+	return wrappedRule as Rule;
+};
+
+/**
+ * Wraps a Stylelint rule with deterministic `context.newline` override.
+ *
+ * @param   plugin_        Stylelint plugin object.
+ * @param   newlineStyle   Newline style to inject into rule contexts.
+ *
+ * @returns                A new plugin instance with wrapped rules.
+ */
+const wrapPluginRule = (plugin_: Plugin, newlineStyle: 'lf' | 'crlf') => {
+	// `deepClone` prevents mutation of shared plugin instances
+	// that may be reused across multiple tests.
+	const plugin = deepClone(plugin_);
+
+	if ('default' in plugin && plugin.default) {
+		plugin.default.rule = withContextNewline(plugin.default.rule, newlineStyle);
+	}
+
+	if ('rule' in plugin && plugin.rule) {
+		plugin.rule = withContextNewline(plugin.rule, newlineStyle);
+	}
+
+	return plugin;
+};
+
+/**
  * Gets options to pass into `stylelint.lint()` method
  * considering test case and schema options.
  *
@@ -32,10 +108,33 @@ const getOutputCss = (linterOutput: LinterResult) => {
  *
  * @returns            Options ready to pass into `stylelint.lint()` method.
  */
-export const getStylelintOptions = (testCase: TestCase, schema: InternalTestRuleSchema): LinterOptions => {
+export const getStylelintOptions = (testCase: TestCase, schema: InternalTestRuleSchema) => {
 	const { testRuleSchema, factorySchema, testUtilsSchema } = schema;
-	const plugins = testRuleSchema.plugins ?? factorySchema.plugins ?? testUtilsSchema.plugins;
 	const ruleName = testRuleSchema.ruleName ?? factorySchema.ruleName;
+
+	let plugins = testRuleSchema.plugins
+		?? factorySchema.plugins
+		?? testUtilsSchema.plugins;
+
+	const newlineFallback = testCase.contextNewlineFallback
+		?? testRuleSchema.contextNewlineFallback
+		?? factorySchema.contextNewlineFallback
+		?? testUtilsSchema.contextNewlineFallback
+		?? 'system';
+
+	// Stylelint uses `node:os.EOL` as a fallback for `context.newline` if source
+	// does not explicitly contain a line break character (`\n`, `\r\n`),
+	// which makes the tests platform-dependent.
+	// This code replaces the context with the specified value in such cases.
+	// @see https://github.com/stylelint/stylelint/issues/9281
+	const codeContainsNewline = !!testCase.code.match(/\r?\n/);
+	if (plugins && !codeContainsNewline && newlineFallback !== 'system') {
+		plugins = toArray(plugins).map((plugin) => {
+			if (isString(plugin)) return plugin;
+
+			return wrapPluginRule(plugin, newlineFallback);
+		});
+	}
 
 	return {
 		code: testCase.code,

--- a/src/utils/test-platform.ts
+++ b/src/utils/test-platform.ts
@@ -1,43 +1,6 @@
-import { isString, isUndefined, toNumber, tsObject } from '@morev/utils';
-import stylelint from 'stylelint';
+import { tsObject } from '@morev/utils';
 import type { PlainObject } from '@morev/utils';
-import type { LinterOptions, LinterResult } from 'stylelint';
-import type { CreateTestUtilsSchema, TestCase, TestFunctions } from '#types';
-import type { InternalTestRuleSchema } from '#types/internal';
-
-/**
- * Gets the resulting CSS string from the `linterOutput`,
- * checking for necessary parts in the process.
- *
- * @param   linterOutput   Stylelint output.
- *
- * @returns                Resulting CSS string of the Stylelint output
- *                         or `null` in case of an error.
- */
-const getOutputCss = (linterOutput: LinterResult) => {
-	const { results } = linterOutput;
-	const { _postcssResult: result } = results[0];
-
-	if (result?.root && result?.opts) {
-		return result.root.toString(result.opts.syntax);
-	}
-
-	return null;
-};
-
-/**
- * Clears the object of keys that have the value `undefined`.
- *
- * @param   source   The source object.
- *
- * @returns          A new object without keys that was declared as `undefined` in the source object.
- */
-export const omitUndefinedValues = (source: PlainObject<unknown>) => {
-	return tsObject.fromEntries(
-		tsObject.entries(source)
-			.filter(([key, value]) => !isUndefined(value)),
-	);
-};
+import type { CreateTestUtilsSchema, TestFunctions } from '#types';
 
 /**
  * Conditionally applies `skip` or `only` modifier to the base `it` or `describe` function.
@@ -58,80 +21,6 @@ export const applyModifiers = <T extends Exclude<TestFunctions['describe'], unde
 		: modifiers.skip
 			? baseEntity.skip as T
 			: baseEntity;
-};
-
-/**
- * Gets options to pass into `stylelint.lint()` method
- * considering test case and schema options.
- *
- * @param   testCase   A test case.
- * @param   schema     A test schema.
- *
- * @returns            Options ready to pass into `stylelint.lint()` method.
- */
-export const getStylelintOptions = (testCase: TestCase, schema: InternalTestRuleSchema): LinterOptions => {
-	const { testRuleSchema, factorySchema, testUtilsSchema } = schema;
-	const plugins = testRuleSchema.plugins ?? factorySchema.plugins ?? testUtilsSchema.plugins;
-	const ruleName = testRuleSchema.ruleName ?? factorySchema.ruleName;
-
-	return {
-		code: testCase.code,
-		config: {
-			plugins,
-			rules: {
-				[ruleName]: testRuleSchema.config,
-				...testUtilsSchema.extraRules,
-				...factorySchema.extraRules,
-				...testRuleSchema.extraRules,
-			},
-		},
-		customSyntax: (() => {
-			if ('customSyntax' in testCase) return testCase.customSyntax;
-			if ('customSyntax' in testRuleSchema) return testRuleSchema.customSyntax;
-			if ('customSyntax' in factorySchema) return factorySchema.customSyntax;
-			return testUtilsSchema.customSyntax;
-		})(),
-		codeFilename: (() => {
-			if ('codeFilename' in testCase) return testCase.codeFilename;
-			if ('codeFilename' in testRuleSchema) return testRuleSchema.codeFilename;
-		})(),
-	};
-};
-
-/**
- * Runs `stylelint.lint` method with specified options.
- *
- * @param   options   Stylelint options.
- *
- * @returns           An object containing linter output and its extracted result.
- */
-export const lintWithOptions = async (options: LinterOptions) => {
-	const output = await stylelint.lint(options);
-	const { results: [result] } = output;
-	const outputCss = getOutputCss(output);
-
-	return { output, result, outputCss };
-};
-
-/**
- * Retrieves (from a stack trace) the line number of the call
- * that follows the call with the specified function.
- *
- * @param   previousCallFunctionName   The name of the function that precedes the desired output.
- *
- * @returns                            Number of the line or `null` in case it could not be determined.
- */
-export const fetchErrorLine = (previousCallFunctionName: string) => {
-	try {
-		throw new Error('error-to-catch-the-line');
-	} catch (error: any) {
-		if (!error.stack || !isString(error.stack)) return null;
-		const stack = error.stack.split('\n');
-		const errorFileLineIndex = stack
-			.findIndex((item: string) => item.includes(previousCallFunctionName)) + 1;
-
-		return toNumber(stack[errorFileLineIndex]?.match(/(\d+):\d+$/)?.[1], null);
-	}
 };
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
 		"paths": {
 			"#": ["./src/index.ts"],
 			"#lib": ["./src/lib/index.ts"],
-			"#utils": ["./src/utils.ts"],
+			"#utils": ["./src/utils/index.ts"],
 			"#types": ["./src/types/index.ts"],
 			"#types/internal": ["./src/types/internal/index.ts"],
 		},


### PR DESCRIPTION
This PR adds the ability to make tests that rely on `context.newline`, provided by Stylelint, deterministic across different operating systems.

The `contextNewlineFallback` option has been added, tested and documented, allowing us to specify a specific linebreak at any level (when creating test utilities, defining a rule's test function, or even at the level of individual tests).

You can read the details of the issue [in the Stylelint repository](https://github.com/stylelint/stylelint/issues/9281).